### PR TITLE
feat: add base structure with pages and tests

### DIFF
--- a/pages/ContactPage.ts
+++ b/pages/ContactPage.ts
@@ -1,0 +1,58 @@
+import { Page, Locator, expect } from '@playwright/test';
+
+export class ContactPage {
+  readonly page: Page;
+  readonly firstNameInput: Locator;
+  readonly lastNameInput: Locator;
+  readonly emailInput: Locator;
+  readonly genderRadioLabel: Locator;
+  readonly phoneInput: Locator;
+  readonly submitBtn: Locator;
+  readonly modalTitle: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.firstNameInput = page.locator('#firstName');
+    this.lastNameInput = page.locator('#lastName');
+    this.emailInput = page.locator('#userEmail');
+    this.genderRadioLabel = page.locator('label[for="gender-radio-1"]');
+    this.phoneInput = page.locator('#userNumber');
+    this.submitBtn = page.locator('#submit');
+    this.modalTitle = page.locator('#example-modal-sizes-title-lg');
+  }
+
+  async goto() {
+    await this.page.goto('https://demoqa.com/automation-practice-form', { waitUntil: 'domcontentloaded' });
+  }
+
+  async fillForm(first: string, last: string, email: string) {
+    await this.firstNameInput.fill(first);
+    await this.lastNameInput.fill(last);
+    await this.emailInput.fill(email);
+
+    const isBlocked = await this.genderRadioLabel.evaluate((el) => {
+      const rect = el.getBoundingClientRect();
+      const elemAtPoint = document.elementFromPoint(rect.left + 5, rect.top + 5);
+      return elemAtPoint !== el;
+    });
+
+    if (isBlocked) {
+      await this.page.evaluate(() => {
+        const ad = document.querySelector('#fixedban');
+        if (ad) ad.remove();
+      });
+    }
+
+    await this.genderRadioLabel.click();
+    await this.phoneInput.fill('0123456789');
+  }
+
+  async submitForm() {
+    await this.submitBtn.scrollIntoViewIfNeeded();
+    await this.submitBtn.click();
+  }
+
+  async assertModalVisible() {
+    await expect(this.modalTitle).toBeVisible({ timeout: 5000 });
+  }
+}

--- a/pages/HomePage.ts
+++ b/pages/HomePage.ts
@@ -1,0 +1,21 @@
+import { Page } from "@playwright/test";
+
+export class HomePage {
+  constructor(private page: Page) {}
+
+  async goto() {
+    await this.page.goto("/");
+  }
+
+  async clickFormsSection() {
+    await this.page.getByText("Forms").click();
+  }
+
+  async clickPracticeForm() {
+    await this.page.getByText("Practice Form").click();
+  }
+
+  async isElementsSectionVisible() {
+    return this.page.isVisible("text=Elements");
+  }
+}

--- a/tests/contact.spec.ts
+++ b/tests/contact.spec.ts
@@ -1,0 +1,10 @@
+import { test } from '@playwright/test';
+import { ContactPage } from '../pages/ContactPage';
+
+test('Contact Page: fill and submit form with confirmation', async ({ page }) => {
+  const contact = new ContactPage(page);
+  await contact.goto();
+  await contact.fillForm('John', 'Doe', 'john@example.com');
+  await contact.submitForm();
+  await contact.assertModalVisible();
+});

--- a/tests/example.spec.ts
+++ b/tests/example.spec.ts
@@ -1,18 +1,20 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from "@playwright/test";
 
-test('has title', async ({ page }) => {
-  await page.goto('https://playwright.dev/');
+test("has title", async ({ page }) => {
+  await page.goto("https://playwright.dev/");
 
   // Expect a title "to contain" a substring.
   await expect(page).toHaveTitle(/Playwright/);
 });
 
-test('get started link', async ({ page }) => {
-  await page.goto('https://playwright.dev/');
+test("get started link", async ({ page }) => {
+  await page.goto("https://playwright.dev/");
 
   // Click the get started link.
-  await page.getByRole('link', { name: 'Get started' }).click();
+  await page.getByRole("link", { name: "Get started" }).click();
 
   // Expects page to have a heading with the name of Installation.
-  await expect(page.getByRole('heading', { name: 'Installation' })).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "Installation" })
+  ).toBeVisible();
 });

--- a/tests/home.spec.ts
+++ b/tests/home.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from "@playwright/test";
+import { HomePage } from "../pages/HomePage";
+
+test("Main Page - Display of the Elements section", async ({ page }) => {
+  const home = new HomePage(page);
+  await home.goto();
+  expect(await home.isElementsSectionVisible()).toBeTruthy();
+});
+
+test("Main Page - Navigate to the form", async ({ page }) => {
+  const home = new HomePage(page);
+  await home.goto();
+  await home.clickFormsSection();
+  await home.clickPracticeForm();
+  await expect(page).toHaveURL(/.*automation-practice-form/);
+});


### PR DESCRIPTION
### ✅ What was added:
- `pages/HomePage.ts` — Page Object for the main page with navigation methods (e.g., Forms → Practice Form)
- `pages/ContactPage.ts` — Page Object for the contact form, including locators, form filling, submit logic, and modal assertion
- `tests/home.spec.ts` — tests to verify visibility of the "Elements" section and navigation to Practice Form
- `tests/contact.spec.ts` — test that fills out and submits the contact form and verifies success modal
- `.gitignore`, `package.json`, `package-lock.json` — base project setup and dependencies
- `playwright.config.ts` — basic Playwright configuration file
- `README.md` — initial project starter documentation

---

### 📌 Why:
- Established Playwright automation framework structure using Page Object Model (POM)
- Covered core test scenarios for navigation and form interaction on demoqa.com
- Improved test maintainability and reusability via page abstraction

---

### 🧪 How to test:
1. Install dependencies:  
npm install

2. Run all tests:  
npx playwright test

3. Run a specific test file:  
npx playwright test tests/contact.spec.ts

4. Commit and push your changes:  
git add .  
git commit -m "feat: add base pages and tests with initial setup"  
git push origin feature/add-pages-and-tests
